### PR TITLE
Cleanup stuff for 2.0 version

### DIFF
--- a/reset.css
+++ b/reset.css
@@ -5,9 +5,56 @@
   - http://meyerweb.com
   - http://html5doctor.com
   - http://html5boilerplate.com
+
+  … and then cleaned up a lot.
 */
 
-html, body, body div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, abbr, address, cite, code, del, dfn, em, img, ins, kbd, q, samp, small, strong, sub, sup, var, b, i, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, figure, footer, header, menu, nav, section, time, mark, audio, video, details, summary {
+html,
+body,
+div,
+span,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+abbr,
+code,
+em,
+img,
+small,
+strong,
+sub,
+sup,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+footer,
+header,
+nav,
+section,
+time,
+audio,
+video {
   margin: 0;
   padding: 0;
   border: 0;
@@ -17,10 +64,19 @@ html, body, body div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquot
   background: transparent;
 }
 
-article, aside, figure, footer, header, nav, section, details, summary {display: block;}
+article,
+aside,
+figure,
+footer,
+header,
+nav,
+section {
+  display: block;
+}
 
 html {
   box-sizing: border-box;
+  overflow-y: scroll;
 }
 
 *,
@@ -30,78 +86,55 @@ html {
 }
 
 img,
-object,
-embed {max-width: 100%;}
-
-html {overflow-y: scroll;}
-
-ul {list-style: none;}
-
-blockquote, q {quotes: none;}
-
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {content: ''; content: none;}
-
-a {margin: 0; padding: 0; font-size: 100%; vertical-align: baseline; background: transparent;}
-
-del {text-decoration: line-through;}
-
-abbr[title], dfn[title] {border-bottom: 1px dotted #000; cursor: help;}
-
-/* tables still need cellspacing="0" in the markup */
-table {border-collapse: collapse; border-spacing: 0;}
-th {font-weight: bold; vertical-align: bottom;}
-td {font-weight: normal; vertical-align: top;}
-
-hr {display: block; height: 1px; border: 0; border-top: 1px solid #ccc; margin: 1em 0; padding: 0;}
-
-input, select {vertical-align: middle;}
-
-pre {
-    white-space: pre; /* CSS2 */
-    white-space: pre-wrap; /* CSS 2.1 */
-    white-space: pre-line; /* CSS 3 (and 2.1 as well, actually) */
-    word-wrap: break-word; /* IE */
+object {
+  max-width: 100%;
 }
 
-input[type="radio"] {vertical-align: text-bottom;}
-input[type="checkbox"] {vertical-align: bottom;}
-.ie7 input[type="checkbox"] {vertical-align: baseline;}
-.ie6 input {vertical-align: text-bottom;}
+ul {
+  list-style: none;
+}
 
-select, input, textarea {font: 99% sans-serif;}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
 
-table {font-size: inherit; font: 100%;}
+th {
+  font-weight: bold;
+  vertical-align: bottom;
+}
 
-small {font-size: 85%;}
+td {
+  font-weight: normal;
+  vertical-align: top;
+}
 
-strong {font-weight: bold;}
+input,
+select {
+  vertical-align: middle;
+}
 
-td, td img {vertical-align: top;}
+input[type="radio"] {
+  vertical-align: text-bottom;
+}
 
-sub, sup {font-size: 75%; line-height: 0; position: relative;}
-sup {top: -0.5em;}
-sub {bottom: -0.25em;}
+input[type="checkbox"] {
+  vertical-align: bottom;
+}
 
-pre, code, kbd, samp {font-family: monospace, sans-serif;}
+strong {
+  font-weight: bold;
+}
 
-.clickable,
 label,
-input[type=button],
-input[type=submit],
-input[type=file],
-button {cursor: pointer;}
-
-button, input, select, textarea {margin: 0;}
+input[type="file"],
+button {
+  cursor: pointer;
+}
 
 button,
-input[type=button] {width: auto; overflow: visible;}
-
-.ie7 img {-ms-interpolation-mode: bicubic;}
-
-/* let's clear some floats */
-.clearfix:before, .clearfix:after { content: "\0020"; display: block; height: 0; overflow: hidden; }
-.clearfix:after { clear: both; }
-.clearfix { zoom: 1; }
+input,
+select,
+textarea {
+  margin: 0;
+}


### PR DESCRIPTION
You’re probably better off reviewing the [whole file](https://github.com/mirego/simple-css-reset/blob/feature/cleanup-for-2.0/reset.css).

I basically ended up cleanup up the syntax inconstancies as well as removing useless selectors and properties. Hopefully after this PR we’ll be able to release a 2.0 version that satisfy us all :grinning: 
