### PR TITLE
Remove the 'font-weight: normal;'

### DIFF
--- a/reset.css
+++ b/reset.css
@@ -59,7 +59,7 @@ video {
   padding: 0;
   border: 0;
   font-size: 100%;
-  font-weight: normal;
+  font-weight: inherit;
   vertical-align: baseline;
   background: transparent;
 }


### PR DESCRIPTION
I removed the line `font-weight: normal;` because it was assigned to almost all elements.

For example, if I have `<strong> Foo <span> Bar </ span> </ strong>`, my `bar` text will not be bold because the `<span>` tag has `font-weight : normal;`.
