### PR TITLE
Bump to semantic version 1.0.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-css-reset",
-  "version": "1.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/mirego/simple-css-reset",
   "authors": [
     "Rémi Prévost <rprevost@mirego.com>"


### PR DESCRIPTION
Ember doesn't like non-semantic versions so I'm bumping it to `1.0.1`.

```
> ember build
Invalid Version: 1.0
TypeError: Invalid Version: 1.0
```
