### PR TITLE
Reset moz-focus-inner

### DIFF
--- a/reset.css
+++ b/reset.css
@@ -139,3 +139,8 @@ textarea {
   margin: 0;
   border: 0;
 }
+
+button::-moz-focus-inner {
+  padding: 0;
+  border: 0
+}


### PR DESCRIPTION
Without these properties, it’s impossible to completely reset the extra padding Firefox sets on `<button>` elements.
