### PR TITLE
Fix Chrome’s new button style

### DIFF
--- a/reset.css
+++ b/reset.css
@@ -127,17 +127,26 @@ strong {
 }
 
 label,
-input[type="file"],
-button {
+input[type="file"] {
   cursor: pointer;
 }
 
-button,
 input,
 select,
 textarea {
   margin: 0;
   border: 0;
+}
+
+button,
+input[type="button"],
+input[type="submit"] {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  margin: 0;
+  background: transparent;
+  cursor: pointer;
 }
 
 button::-moz-focus-inner {


### PR DESCRIPTION
Chrome now adds `border-radius` by default on buttons, we remove it to avoid cross-browser layout disparity.

Edit: I regrouped button styles together at the same time