### PR TITLE
Properly reset buttons and inputs on mac os / chrome

### DIFF
--- a/reset.css
+++ b/reset.css
@@ -136,8 +136,11 @@ button,
 input,
 select,
 textarea {
+  padding: 0;
   margin: 0;
   border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 button::-moz-focus-inner {


### PR DESCRIPTION
Only for macOS.

```
 The default stylesheet for <button>, <input type=button>,
<input type=reset>, <input type=submit>, a button in 
<input type=file> was changed in order to match OS-native buttons. 
```
 
 Background-color, border, border-radius, and padding were changed.

>https://www.chromestatus.com/features/5743649186906112