### PR TITLE
Set a default color for background-color and color for body

### DIFF
--- a/reset.css
+++ b/reset.css
@@ -79,6 +79,12 @@ html {
   overflow-y: scroll;
 }
 
+html,
+body {
+  background-color: #fff;
+  color: #000;
+}
+
 *,
 *::before,
 *::after {


### PR DESCRIPTION
Mojave Safari's dark mode and some accessibility features can
mess with the default colors. Let's nail them :boom:.