### PR TITLE
Feature/add resets for inputs

### DIFF
--- a/reset.css
+++ b/reset.css
@@ -141,6 +141,7 @@ input,
 select,
 textarea {
   border: 0;
+  border-radius: 0;
   margin: 0;
 }
 

--- a/reset.css
+++ b/reset.css
@@ -153,6 +153,7 @@ input[type='submit'] {
   border-radius: 0;
   margin: 0;
   background: transparent;
+  appearance: none;
   cursor: pointer;
 }
 


### PR DESCRIPTION
We add resets for `border-radius` on inputs, and `appearance` on buttons to make sure iOS platform styles are not overriding our CSS.